### PR TITLE
chore: fix StandardError when running rake db:migrate on a newly created db

### DIFF
--- a/db/migrate/20141116080254_devise_create_users.rb
+++ b/db/migrate/20141116080254_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[5.0]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20141116080738_add_fields_to_user.rb
+++ b/db/migrate/20141116080738_add_fields_to_user.rb
@@ -1,4 +1,4 @@
-class AddFieldsToUser < ActiveRecord::Migration
+class AddFieldsToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :first_name, :string
     add_column :users, :last_name, :string

--- a/db/migrate/20141116081214_create_project_statuses.rb
+++ b/db/migrate/20141116081214_create_project_statuses.rb
@@ -1,4 +1,4 @@
-class CreateProjectStatuses < ActiveRecord::Migration
+class CreateProjectStatuses < ActiveRecord::Migration[5.0]
   def change
     create_table :project_statuses do |t|
       t.string :slug

--- a/db/migrate/20141116081653_create_projects.rb
+++ b/db/migrate/20141116081653_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[5.0]
   def change
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20141116190417_create_project_categories.rb
+++ b/db/migrate/20141116190417_create_project_categories.rb
@@ -1,4 +1,4 @@
-class CreateProjectCategories < ActiveRecord::Migration
+class CreateProjectCategories < ActiveRecord::Migration[5.0]
   def change
     create_table :project_categories do |t|
       t.string :slug

--- a/db/migrate/20141116190914_create_project_category_joinings.rb
+++ b/db/migrate/20141116190914_create_project_category_joinings.rb
@@ -1,4 +1,4 @@
-class CreateProjectCategoryJoinings < ActiveRecord::Migration
+class CreateProjectCategoryJoinings < ActiveRecord::Migration[5.0]
   def change
     create_table :project_category_joinings do |t|
       t.references :project, index: true

--- a/db/migrate/20141116191351_create_skill_categories.rb
+++ b/db/migrate/20141116191351_create_skill_categories.rb
@@ -1,4 +1,4 @@
-class CreateSkillCategories < ActiveRecord::Migration
+class CreateSkillCategories < ActiveRecord::Migration[5.0]
   def change
     create_table :skill_categories do |t|
       t.string :name

--- a/db/migrate/20141116191505_create_skills.rb
+++ b/db/migrate/20141116191505_create_skills.rb
@@ -1,4 +1,4 @@
-class CreateSkills < ActiveRecord::Migration
+class CreateSkills < ActiveRecord::Migration[5.0]
   def change
     create_table :skills do |t|
       t.string :name

--- a/db/migrate/20141116191643_create_work_experiences.rb
+++ b/db/migrate/20141116191643_create_work_experiences.rb
@@ -1,4 +1,4 @@
-class CreateWorkExperiences < ActiveRecord::Migration
+class CreateWorkExperiences < ActiveRecord::Migration[5.0]
   def change
     create_table :work_experiences do |t|
       t.string :organization

--- a/db/migrate/20141116191717_create_education_experiences.rb
+++ b/db/migrate/20141116191717_create_education_experiences.rb
@@ -1,4 +1,4 @@
-class CreateEducationExperiences < ActiveRecord::Migration
+class CreateEducationExperiences < ActiveRecord::Migration[5.0]
   def change
     create_table :education_experiences do |t|
       t.string :school_name

--- a/db/migrate/20141116191847_create_resumes.rb
+++ b/db/migrate/20141116191847_create_resumes.rb
@@ -1,4 +1,4 @@
-class CreateResumes < ActiveRecord::Migration
+class CreateResumes < ActiveRecord::Migration[5.0]
   def change
     create_table :resumes do |t|
       t.references :user, index: true

--- a/db/migrate/20141116191923_create_resume_education_experiences.rb
+++ b/db/migrate/20141116191923_create_resume_education_experiences.rb
@@ -1,4 +1,4 @@
-class CreateResumeEducationExperiences < ActiveRecord::Migration
+class CreateResumeEducationExperiences < ActiveRecord::Migration[5.0]
   def change
     create_table :resume_education_experiences do |t|
       t.references :resume, index: true

--- a/db/migrate/20141116191938_create_resume_work_experiences.rb
+++ b/db/migrate/20141116191938_create_resume_work_experiences.rb
@@ -1,4 +1,4 @@
-class CreateResumeWorkExperiences < ActiveRecord::Migration
+class CreateResumeWorkExperiences < ActiveRecord::Migration[5.0]
   def change
     create_table :resume_work_experiences do |t|
       t.references :resume, index: true

--- a/db/migrate/20141116192037_create_resume_skills.rb
+++ b/db/migrate/20141116192037_create_resume_skills.rb
@@ -1,4 +1,4 @@
-class CreateResumeSkills < ActiveRecord::Migration
+class CreateResumeSkills < ActiveRecord::Migration[5.0]
   def change
     create_table :resume_skills do |t|
       t.references :resume, index: true

--- a/db/migrate/20141116192126_create_resume_projects.rb
+++ b/db/migrate/20141116192126_create_resume_projects.rb
@@ -1,4 +1,4 @@
-class CreateResumeProjects < ActiveRecord::Migration
+class CreateResumeProjects < ActiveRecord::Migration[5.0]
   def change
     create_table :resume_projects do |t|
       t.references :resume, index: true

--- a/db/migrate/20141116193555_add_user_to_work_experience.rb
+++ b/db/migrate/20141116193555_add_user_to_work_experience.rb
@@ -1,4 +1,4 @@
-class AddUserToWorkExperience < ActiveRecord::Migration
+class AddUserToWorkExperience < ActiveRecord::Migration[5.0]
   def change
     add_reference :work_experiences, :user, index: true
   end

--- a/db/migrate/20141116193603_add_user_to_education_experience.rb
+++ b/db/migrate/20141116193603_add_user_to_education_experience.rb
@@ -1,4 +1,4 @@
-class AddUserToEducationExperience < ActiveRecord::Migration
+class AddUserToEducationExperience < ActiveRecord::Migration[5.0]
   def change
     add_reference :education_experiences, :user, index: true
   end

--- a/db/migrate/20141116213915_add_user_to_project.rb
+++ b/db/migrate/20141116213915_add_user_to_project.rb
@@ -1,4 +1,4 @@
-class AddUserToProject < ActiveRecord::Migration
+class AddUserToProject < ActiveRecord::Migration[5.0]
   def change
     add_reference :projects, :user, index: true
   end

--- a/db/migrate/20141116222410_add_github_url_to_project.rb
+++ b/db/migrate/20141116222410_add_github_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddGithubUrlToProject < ActiveRecord::Migration
+class AddGithubUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :github_url, :string
   end

--- a/db/migrate/20141117000510_add_position_to_work_experience.rb
+++ b/db/migrate/20141117000510_add_position_to_work_experience.rb
@@ -1,4 +1,4 @@
-class AddPositionToWorkExperience < ActiveRecord::Migration
+class AddPositionToWorkExperience < ActiveRecord::Migration[5.0]
   def change
     add_column :work_experiences, :position, :string
   end

--- a/db/migrate/20141117000748_add_diploma_to_education_experience.rb
+++ b/db/migrate/20141117000748_add_diploma_to_education_experience.rb
@@ -1,4 +1,4 @@
-class AddDiplomaToEducationExperience < ActiveRecord::Migration
+class AddDiplomaToEducationExperience < ActiveRecord::Migration[5.0]
   def change
     add_column :education_experiences, :diploma, :string
   end

--- a/db/migrate/20141204194715_add_tagline_to_user.rb
+++ b/db/migrate/20141204194715_add_tagline_to_user.rb
@@ -1,4 +1,4 @@
-class AddTaglineToUser < ActiveRecord::Migration
+class AddTaglineToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :tagline, :string
   end

--- a/db/migrate/20141204194825_add_header_image_url_to_user.rb
+++ b/db/migrate/20141204194825_add_header_image_url_to_user.rb
@@ -1,4 +1,4 @@
-class AddHeaderImageURLToUser < ActiveRecord::Migration
+class AddHeaderImageUrlToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :header_image_url, :string
   end

--- a/db/migrate/20141204200615_rename_resume_description_to_background.rb
+++ b/db/migrate/20141204200615_rename_resume_description_to_background.rb
@@ -1,4 +1,4 @@
-class RenameResumeDescriptionToBackground < ActiveRecord::Migration
+class RenameResumeDescriptionToBackground < ActiveRecord::Migration[5.0]
   def change
     rename_column :resumes, :description, :background
   end

--- a/db/migrate/20141204200828_add_description_to_resume.rb
+++ b/db/migrate/20141204200828_add_description_to_resume.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToResume < ActiveRecord::Migration
+class AddDescriptionToResume < ActiveRecord::Migration[5.0]
   def change
     add_column :resumes, :description, :string
   end

--- a/db/migrate/20141205023301_add_social_networks_handles_to_user.rb
+++ b/db/migrate/20141205023301_add_social_networks_handles_to_user.rb
@@ -1,4 +1,4 @@
-class AddSocialNetworksHandlesToUser < ActiveRecord::Migration
+class AddSocialNetworksHandlesToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :github_handle, :string
     add_column :users, :googleplus_handle, :string

--- a/db/migrate/20141206235159_add_subdomain_and_domain_to_user.rb
+++ b/db/migrate/20141206235159_add_subdomain_and_domain_to_user.rb
@@ -1,4 +1,4 @@
-class AddSubdomainAndDomainToUser < ActiveRecord::Migration
+class AddSubdomainAndDomainToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :subdomain, :string
     add_index :users, :subdomain, unique: true

--- a/db/migrate/20141207061056_allow_user_domain_to_be_null.rb
+++ b/db/migrate/20141207061056_allow_user_domain_to_be_null.rb
@@ -1,4 +1,4 @@
-class AllowUserDomainToBeNull < ActiveRecord::Migration
+class AllowUserDomainToBeNull < ActiveRecord::Migration[5.0]
   def change
     change_column_null :users, :domain, true
   end

--- a/db/migrate/20141214202908_add_avatar_label_to_user.rb
+++ b/db/migrate/20141214202908_add_avatar_label_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarLabelToUser < ActiveRecord::Migration
+class AddAvatarLabelToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :avatar_label, :string
   end

--- a/db/migrate/20150101023016_create_types.rb
+++ b/db/migrate/20150101023016_create_types.rb
@@ -1,4 +1,4 @@
-class CreateTypes < ActiveRecord::Migration
+class CreateTypes < ActiveRecord::Migration[5.0]
   def change
     create_table :types do |t|
       t.string :name

--- a/db/migrate/20150101031509_rename_user_type_join_table.rb
+++ b/db/migrate/20150101031509_rename_user_type_join_table.rb
@@ -1,4 +1,4 @@
-class RenameUserTypeJoinTable < ActiveRecord::Migration
+class RenameUserTypeJoinTable < ActiveRecord::Migration[5.0]
   def change
     rename_table :types_users, :user_types
   end

--- a/db/migrate/20150101035457_add_vimeo_url_to_project.rb
+++ b/db/migrate/20150101035457_add_vimeo_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddVimeoURLToProject < ActiveRecord::Migration
+class AddVimeoUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :vimeo_url, :string
   end

--- a/db/migrate/20150101042342_add_url_to_project.rb
+++ b/db/migrate/20150101042342_add_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddURLToProject < ActiveRecord::Migration
+class AddUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :soundcloud_url, :string
   end

--- a/db/migrate/20150101042404_add_bandcamp_url_to_project.rb
+++ b/db/migrate/20150101042404_add_bandcamp_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddBandcampURLToProject < ActiveRecord::Migration
+class AddBandcampUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :bandcamp_url, :string
   end

--- a/db/migrate/20150101042548_add_penflip_url_to_project.rb
+++ b/db/migrate/20150101042548_add_penflip_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddPenflipURLToProject < ActiveRecord::Migration
+class AddPenflipUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :penflip_url, :string
   end

--- a/db/migrate/20150101042654_add_you_tube_url_to_project.rb
+++ b/db/migrate/20150101042654_add_you_tube_url_to_project.rb
@@ -1,4 +1,4 @@
-class AddYouTubeURLToProject < ActiveRecord::Migration
+class AddYouTubeUrlToProject < ActiveRecord::Migration[5.0]
   def change
     add_column :projects, :youtube_url, :string
   end

--- a/db/migrate/20150112023222_add_sound_cloud_handle_to_user.rb
+++ b/db/migrate/20150112023222_add_sound_cloud_handle_to_user.rb
@@ -1,4 +1,4 @@
-class AddSoundCloudHandleToUser < ActiveRecord::Migration
+class AddSoundCloudHandleToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :soundcloud_handle, :string
   end

--- a/db/migrate/20150112024451_add_tumblr_url_to_user.rb
+++ b/db/migrate/20150112024451_add_tumblr_url_to_user.rb
@@ -1,4 +1,4 @@
-class AddTumblrURLToUser < ActiveRecord::Migration
+class AddTumblrUrlToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :tumblr_url, :string
   end

--- a/db/migrate/20150112030010_add_vimeo_and_you_tube_handles_to_user.rb
+++ b/db/migrate/20150112030010_add_vimeo_and_you_tube_handles_to_user.rb
@@ -1,4 +1,4 @@
-class AddVimeoAndYouTubeHandlesToUser < ActiveRecord::Migration
+class AddVimeoAndYouTubeHandlesToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :vimeo_handle, :string
     add_column :users, :youtube_handle, :string

--- a/db/migrate/20150112194551_add_header_image_to_users.rb
+++ b/db/migrate/20150112194551_add_header_image_to_users.rb
@@ -1,4 +1,4 @@
-class AddHeaderImageToUsers < ActiveRecord::Migration
+class AddHeaderImageToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :header_image, :string
   end

--- a/db/migrate/20150112201210_remove_header_image_url_from_users.rb
+++ b/db/migrate/20150112201210_remove_header_image_url_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveHeaderImageURLFromUsers < ActiveRecord::Migration
+class RemoveHeaderImageUrlFromUsers < ActiveRecord::Migration[5.0]
   def change
     remove_column :users, :header_image_url, :string
   end

--- a/db/migrate/20150122195402_add_header_media_type_to_user.rb
+++ b/db/migrate/20150122195402_add_header_media_type_to_user.rb
@@ -1,4 +1,4 @@
-class AddHeaderMediaTypeToUser < ActiveRecord::Migration
+class AddHeaderMediaTypeToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :header_media_type, :integer, default: 0
   end

--- a/db/migrate/20150123024426_add_header_video_to_user.rb
+++ b/db/migrate/20150123024426_add_header_video_to_user.rb
@@ -1,4 +1,4 @@
-class AddHeaderVideoToUser < ActiveRecord::Migration
+class AddHeaderVideoToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :header_video, :string
   end

--- a/db/migrate/20150123024508_add_avatar_image_to_user.rb
+++ b/db/migrate/20150123024508_add_avatar_image_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarImageToUser < ActiveRecord::Migration
+class AddAvatarImageToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :avatar_image, :string
   end

--- a/db/migrate/20150124014603_add_avatar_image_processing_to_user.rb
+++ b/db/migrate/20150124014603_add_avatar_image_processing_to_user.rb
@@ -1,4 +1,4 @@
-class AddAvatarImageProcessingToUser < ActiveRecord::Migration
+class AddAvatarImageProcessingToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :avatar_image_processing, :boolean, null: false, default: false
   end

--- a/db/migrate/20150124014721_add_header_video_processing_to_user.rb
+++ b/db/migrate/20150124014721_add_header_video_processing_to_user.rb
@@ -1,4 +1,4 @@
-class AddHeaderVideoProcessingToUser < ActiveRecord::Migration
+class AddHeaderVideoProcessingToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :header_video_processing, :boolean, null: false, default: false
   end

--- a/db/migrate/20150125202234_add_admin_to_users.rb
+++ b/db/migrate/20150125202234_add_admin_to_users.rb
@@ -1,4 +1,4 @@
-class AddAdminToUsers < ActiveRecord::Migration
+class AddAdminToUsers < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :admin, :boolean, :default => false
   end

--- a/db/migrate/20150218222122_create_posts.rb
+++ b/db/migrate/20150218222122_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration
+class CreatePosts < ActiveRecord::Migration[5.0]
   def change
     create_table :posts do |t|
       t.string :title

--- a/db/migrate/20150218222429_create_friendly_id_slugs.rb
+++ b/db/migrate/20150218222429_create_friendly_id_slugs.rb
@@ -1,4 +1,4 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.0]
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/db/migrate/20150221032301_add_published_on_to_post.rb
+++ b/db/migrate/20150221032301_add_published_on_to_post.rb
@@ -1,4 +1,4 @@
-class AddPublishedOnToPost < ActiveRecord::Migration
+class AddPublishedOnToPost < ActiveRecord::Migration[5.0]
   def change
     add_column :posts, :published_on, :datetime
   end

--- a/db/migrate/20150221200127_create_post_categories.rb
+++ b/db/migrate/20150221200127_create_post_categories.rb
@@ -1,4 +1,4 @@
-class CreatePostCategories < ActiveRecord::Migration
+class CreatePostCategories < ActiveRecord::Migration[5.0]
   def change
     create_table :post_categories do |t|
       t.string :name

--- a/db/migrate/20150221200246_create_post_category_joinings.rb
+++ b/db/migrate/20150221200246_create_post_category_joinings.rb
@@ -1,4 +1,4 @@
-class CreatePostCategoryJoinings < ActiveRecord::Migration
+class CreatePostCategoryJoinings < ActiveRecord::Migration[5.0]
   def change
     create_table :post_category_joinings do |t|
       t.references :post, index: true

--- a/db/migrate/20150317062502_add_google_analytics_id_to_user.rb
+++ b/db/migrate/20150317062502_add_google_analytics_id_to_user.rb
@@ -1,4 +1,4 @@
-class AddGoogleAnalyticsIdToUser < ActiveRecord::Migration
+class AddGoogleAnalyticsIdToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :google_analytics_id, :string
   end

--- a/db/migrate/20150320025456_add_google_analytics_view_id_to_user.rb
+++ b/db/migrate/20150320025456_add_google_analytics_view_id_to_user.rb
@@ -1,4 +1,4 @@
-class AddGoogleAnalyticsViewIdToUser < ActiveRecord::Migration
+class AddGoogleAnalyticsViewIdToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :ga_view_id, :string
   end

--- a/db/migrate/20150320030406_rename_google_analytics_id_to_ga_property_id.rb
+++ b/db/migrate/20150320030406_rename_google_analytics_id_to_ga_property_id.rb
@@ -1,4 +1,4 @@
-class RenameGoogleAnalyticsIdToGaPropertyId < ActiveRecord::Migration
+class RenameGoogleAnalyticsIdToGaPropertyId < ActiveRecord::Migration[5.0]
   def change
     rename_column :users, :google_analytics_id, :ga_property_id
   end

--- a/db/migrate/20150320033646_remove_tagline_from_post.rb
+++ b/db/migrate/20150320033646_remove_tagline_from_post.rb
@@ -1,4 +1,4 @@
-class RemoveTaglineFromPost < ActiveRecord::Migration
+class RemoveTaglineFromPost < ActiveRecord::Migration[5.0]
   def change
     remove_column :posts, :tagline
   end

--- a/db/migrate/20150506204904_add_user_to_project_status.rb
+++ b/db/migrate/20150506204904_add_user_to_project_status.rb
@@ -1,4 +1,4 @@
-class AddUserToProjectStatus < ActiveRecord::Migration
+class AddUserToProjectStatus < ActiveRecord::Migration[5.0]
   def change
     add_reference :project_statuses, :user, index: true, foreign_key: true
   end

--- a/db/migrate/20150506232257_remove_unique_slug_index_from_project_status.rb
+++ b/db/migrate/20150506232257_remove_unique_slug_index_from_project_status.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueSlugIndexFromProjectStatus < ActiveRecord::Migration
+class RemoveUniqueSlugIndexFromProjectStatus < ActiveRecord::Migration[5.0]
   def change
     remove_index :project_statuses, :slug if index_exists?(:project_statuses, :slug)
   end

--- a/db/migrate/20150506232929_remove_unique_name_index_from_project_status.rb
+++ b/db/migrate/20150506232929_remove_unique_name_index_from_project_status.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueNameIndexFromProjectStatus < ActiveRecord::Migration
+class RemoveUniqueNameIndexFromProjectStatus < ActiveRecord::Migration[5.0]
   def change
     remove_index :project_statuses, :name if index_exists?(:project_statuses, :name)
   end

--- a/db/migrate/20150507015139_add_user_to_skill_category.rb
+++ b/db/migrate/20150507015139_add_user_to_skill_category.rb
@@ -1,4 +1,4 @@
-class AddUserToSkillCategory < ActiveRecord::Migration
+class AddUserToSkillCategory < ActiveRecord::Migration[5.0]
   def change
     add_reference :skill_categories, :user, index: true, foreign_key: true
   end

--- a/db/migrate/20150507015620_remove_unique_name_index_from_skill_category.rb
+++ b/db/migrate/20150507015620_remove_unique_name_index_from_skill_category.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueNameIndexFromSkillCategory < ActiveRecord::Migration
+class RemoveUniqueNameIndexFromSkillCategory < ActiveRecord::Migration[5.0]
   def change
     remove_index :skill_categories, :name if index_exists?(:skill_categories, :name)
   end

--- a/db/migrate/20150507035507_add_user_to_project_category.rb
+++ b/db/migrate/20150507035507_add_user_to_project_category.rb
@@ -1,4 +1,4 @@
-class AddUserToProjectCategory < ActiveRecord::Migration
+class AddUserToProjectCategory < ActiveRecord::Migration[5.0]
   def change
     add_reference :project_categories, :user, index: true, foreign_key: true
   end

--- a/db/migrate/20150507035543_remove_unique_name_and_slug_indices_from_project_category.rb
+++ b/db/migrate/20150507035543_remove_unique_name_and_slug_indices_from_project_category.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueNameAndSlugIndicesFromProjectCategory < ActiveRecord::Migration
+class RemoveUniqueNameAndSlugIndicesFromProjectCategory < ActiveRecord::Migration[5.0]
   def change
     remove_index :project_categories, :name if index_exists?(:project_categories, :name)
     remove_index :project_categories, :slug if index_exists?(:project_categories, :slug)

--- a/db/migrate/20150507042228_add_user_to_post_category.rb
+++ b/db/migrate/20150507042228_add_user_to_post_category.rb
@@ -1,4 +1,4 @@
-class AddUserToPostCategory < ActiveRecord::Migration
+class AddUserToPostCategory < ActiveRecord::Migration[5.0]
   def change
     add_reference :post_categories, :user, index: true, foreign_key: true
   end

--- a/db/migrate/20150507042242_remove_unique_name_and_slug_indices_from_post_category.rb
+++ b/db/migrate/20150507042242_remove_unique_name_and_slug_indices_from_post_category.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueNameAndSlugIndicesFromPostCategory < ActiveRecord::Migration
+class RemoveUniqueNameAndSlugIndicesFromPostCategory < ActiveRecord::Migration[5.0]
   def change
     remove_index :post_categories, :name if index_exists?(:post_categories, :name)
     remove_index :post_categories, :slug if index_exists?(:post_categories, :slug)

--- a/db/migrate/20151010033629_add_medium_handler_to_user.rb
+++ b/db/migrate/20151010033629_add_medium_handler_to_user.rb
@@ -1,4 +1,4 @@
-class AddMediumHandlerToUser < ActiveRecord::Migration
+class AddMediumHandlerToUser < ActiveRecord::Migration[5.0]
   def change
     add_column :users, :medium_handle, :string
   end

--- a/db/migrate/20160301023114_add_slug_to_resume.rb
+++ b/db/migrate/20160301023114_add_slug_to_resume.rb
@@ -1,4 +1,4 @@
-class AddSlugToResume < ActiveRecord::Migration
+class AddSlugToResume < ActiveRecord::Migration[5.0]
   def up
     add_column :resumes, :slug, :string
     add_index :resumes, [:slug, :user_id], unique: true

--- a/db/migrate/20160301023133_add_slug_to_projects.rb
+++ b/db/migrate/20160301023133_add_slug_to_projects.rb
@@ -1,4 +1,4 @@
-class AddSlugToProjects < ActiveRecord::Migration
+class AddSlugToProjects < ActiveRecord::Migration[5.0]
   def up
     add_column :projects, :slug, :string
     add_index :projects, [:slug, :user_id], unique: true

--- a/db/migrate/20161222040334_drop_user_types.rb
+++ b/db/migrate/20161222040334_drop_user_types.rb
@@ -1,4 +1,4 @@
-class DropUserTypes < ActiveRecord::Migration
+class DropUserTypes < ActiveRecord::Migration[5.0]
   def up
     drop_table :user_types
     drop_table :types

--- a/db/migrate/20161222044201_remove_some_social_networks.rb
+++ b/db/migrate/20161222044201_remove_some_social_networks.rb
@@ -1,4 +1,4 @@
-class RemoveSomeSocialNetworks < ActiveRecord::Migration
+class RemoveSomeSocialNetworks < ActiveRecord::Migration[5.0]
   def change
     remove_column :users, :soundcloud_handle
     remove_column :users, :vimeo_handle

--- a/db/migrate/20161227031352_drop_header_video_from_user.rb
+++ b/db/migrate/20161227031352_drop_header_video_from_user.rb
@@ -1,4 +1,4 @@
-class DropHeaderVideoFromUser < ActiveRecord::Migration
+class DropHeaderVideoFromUser < ActiveRecord::Migration[5.0]
   def change
     remove_column :users, :header_media_type
     remove_column :users, :header_video, :string

--- a/db/migrate/20170402204112_create_doorkeeper_tables.rb
+++ b/db/migrate/20170402204112_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[5.0]
   def change
     create_table :oauth_applications do |t|
       t.integer :owner_id,     null: false


### PR DESCRIPTION
My Ruby and Rails knowledge is quite outdated, so I don't really understand why `AddYouTubeURLToProject` have to be changed to `AddYouTubeUrlToProject` to make `db:migrate` works.

rails (6.1.4.6)
When running `rake db:migrate` in the development environment, the following error occurred:
> StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

Also, another error occurred:
> rails aborted!
> NameError: uninitialized constant AddYouTubeUrlToProject
> Did you mean?  AddYouTubeURLToProject